### PR TITLE
feat(styles): use accent colour for spoiler bar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,34 +3,50 @@
  * https://github.com/logonoff/obsidian-inline-spoilers
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-/** Reader **/
-.inline_spoilers-spoiler {
-	background-color: var(--text-normal);
-	color: var(--text-normal);
+/* colors */
+.inline_spoilers-spoiler,
+.inline_spoilers-revealed,
+.inline_spoilers-editor-spoiler,
+.inline_spoilers-editor-spoiler-delimiter { /* obscured */
+	background-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 1.0);
+	color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.0);
 }
 
 .inline_spoilers-revealed,
-.inline_spoilers-revealed .inline_spoilers-spoiler {
-	background-color: var(--code-background);
-	color: var(--code-normal);
-}
-
-/** Editor **/
-.inline_spoilers-editor-spoiler {
-	background-color: var(--text-normal);
-	color: var(--text-normal);
-}
-
 .cm-active .inline_spoilers-editor-spoiler,
-.inline_spoilers-revealed .inline_spoilers-editor-spoiler {
-	background-color: var(--code-background);
-	color: var(--code-normal);
+.cm-active .inline_spoilers-editor-spoiler-delimiter { /* revealed */
+	background-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), calc(1.0/5));
+	color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 1.0);
 }
 
-/** editor - delimiter **/
-.inline_spoilers-editor-spoiler-delimiter {
-	background-color: var(--code-background);
-	color: var(--text-normal);
+/* reader */
+.inline_spoilers-spoiler {
+	border-radius: 0.2em;
+	padding: 0 0.2em;
+}
+
+/* editor */
+:not(.is-live-preview) .inline_spoilers-editor-spoiler,
+:is(.is-live-preview) .cm-active .inline_spoilers-editor-spoiler {
+	border-radius: 0em;
+	padding: 0 0.2em;
+}
+
+:is(.is-live-preview) .inline_spoilers-editor-spoiler {
+	border-radius: 0.2em;
+	padding: 0 0.8em;
+}
+
+/* delimiter */
+.cm-line .inline_spoilers-editor-spoiler-delimiter {
+	&:has(+ .inline_spoilers-editor-spoiler) {
+		border-radius: 0.2em 0 0 0.2em;
+		padding-left: 0.2em;
+	}
+	&:is(.inline_spoilers-editor-spoiler + .inline_spoilers-editor-spoiler-delimiter) {
+		border-radius: 0 0.2em 0.2em 0;
+		padding-right: 0.2em;
+	}
 }
 
 .is-live-preview .inline_spoilers-editor-spoiler-delimiter {


### PR DESCRIPTION
Changed colors, shapes, and spacing of spoilers and delimiters to be more in-line with Obsidian's conventions. Now it uses accent colors. Flexoki was applied in the following screenshots to demonstrate this better.

| ![image](https://github.com/user-attachments/assets/71e195a9-8feb-495f-91f7-2afe43215222) | ![image](https://github.com/user-attachments/assets/9d28ba16-eb5d-4b7d-be64-038506555b5a) | ![image](https://github.com/user-attachments/assets/7b202516-6256-40f0-bb38-d584ee7119fa) |
| - | - | - |